### PR TITLE
Add conditional dependency on semigroups to support building with older GHCs

### DIFF
--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -44,6 +44,9 @@ library
                      , text
                      , unordered-containers
                      , vector
+  if impl(ghc < 8.0)
+    build-depends:
+      semigroups < 0.19
 
 executable             json-diff
   default-language:    Haskell2010


### PR DESCRIPTION
As a hackage trustee, I've also made some hackage metadata revisions to existing versions of aeson-diff to prevent some bad build plans.