### PR TITLE
Update test cases with aeson-1.4.3.0 error messages

### DIFF
--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -1,5 +1,5 @@
 name:                aeson-diff
-version:             1.1.0.6
+version:             1.1.0.7
 synopsis:            Extract and apply patches to JSON documents.
 description:
   .

--- a/test/data/cases/case3-error.txt
+++ b/test/data/cases/case3-error.txt
@@ -1,2 +1,4 @@
 Could not parse patch: when expecting a Array, encountered Object instead
 Error in $: Could not parse patch: expected Array, encountered Object
+
+Error in $: Could not parse patch: expected Array, but encountered Object


### PR DESCRIPTION
aeson-1.4.3.0 causes spurious test failures in aeson-diff due to their changed error messages.

The test suite can already handle this -- just add the new message into the output error file.

https://github.com/thsutton/aeson-diff/issues/48