### PR TITLE
Bump base version bound

### DIFF
--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -34,7 +34,7 @@ library
   exposed-modules:     Data.Aeson.Diff
                      , Data.Aeson.Patch
                      , Data.Aeson.Pointer
-  build-depends:       base >=4.9 && <4.14
+  build-depends:       base >=4.9 && <4.15
                      , aeson
                      , bytestring >= 0.10
                      , edit-distance-vector


### PR DESCRIPTION
Everything seems fine with GHC 8.10 and base 4.14.