### PR TITLE
Add Generic instances

### DIFF
--- a/lib/Data/Aeson/Patch.hs
+++ b/lib/Data/Aeson/Patch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -26,6 +27,7 @@ import           Data.Monoid
 import           Data.Semigroup             (Semigroup)
 import           Data.Vector                (Vector)
 import qualified Data.Vector                as V
+import           GHC.Generics               (Generic)
 
 import Data.Aeson.Pointer
 
@@ -34,7 +36,7 @@ import Data.Aeson.Pointer
 -- | Describes the changes between two JSON documents.
 newtype Patch = Patch
     { patchOperations :: [Operation] }
-  deriving (Eq, Show, Semigroup, Monoid)
+  deriving (Eq, Show, Semigroup, Monoid, Generic)
 
 instance ToJSON Patch where
     toJSON (Patch ops) = toJSON ops
@@ -70,7 +72,7 @@ data Operation
     -- ^ http://tools.ietf.org/html/rfc6902#section-4.3
     | Tst { changePointer :: Pointer, changeValue :: Value }
     -- ^ http://tools.ietf.org/html/rfc6902#section-4.6
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 instance ToJSON Operation where
     toJSON (Add p v) = object

--- a/lib/Data/Aeson/Pointer.hs
+++ b/lib/Data/Aeson/Pointer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 -- | Description: JSON Pointers as described in RFC 6901.
@@ -25,6 +26,7 @@ import           Data.Semigroup             (Semigroup)
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import qualified Data.Vector                as V
+import           GHC.Generics               (Generic)
 
 -- * Patch components
 
@@ -32,7 +34,7 @@ import qualified Data.Vector                as V
 data Key
     = OKey Text -- ^ Traverse a 'Value' with an 'Object' constructor.
     | AKey Int  -- ^ Traverse a 'Value' with an 'Array' constructor.
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 instance ToJSON Key where
     toJSON (OKey t) = String t
@@ -64,7 +66,7 @@ type Path = [Key]
 --
 -- Defined in RFC 6901 <http://tools.ietf.org/html/rfc6901>
 newtype Pointer = Pointer { pointerPath :: Path }
-  deriving (Eq, Ord, Show, Semigroup, Monoid)
+  deriving (Eq, Ord, Show, Semigroup, Monoid, Generic)
 
 -- | Format a 'Pointer' as described in RFC 6901.
 --


### PR DESCRIPTION
Users will be able to define generic instances without having to first derive standalone orphan instances for `Generic`