### PR TITLE
Aeson 2 compatibility and fixed doctests

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,5 @@
-import Distribution.Simple
-main = defaultMain
+import Distribution.Extra.Doctest
+       (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -35,7 +35,7 @@ library
                      , Data.Aeson.Patch
                      , Data.Aeson.Pointer
   build-depends:       base >=4.9 && <4.16
-                     , aeson
+                     , aeson >= 2.0.3
                      , bytestring >= 0.10
                      , edit-distance-vector
                      , hashable
@@ -53,7 +53,7 @@ executable             json-diff
   hs-source-dirs:      src
   main-is:             diff.hs
   build-depends:       base
-                     , aeson
+                     , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , optparse-applicative
@@ -64,7 +64,7 @@ executable             json-patch
   hs-source-dirs:      src
   main-is:             patch.hs
   build-depends:       base
-                     , aeson
+                     , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , optparse-applicative
@@ -76,7 +76,7 @@ test-suite             properties
   main-is:             properties.hs
   build-depends:       base
                      , QuickCheck
-                     , aeson
+                     , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , quickcheck-instances
@@ -92,7 +92,7 @@ test-suite             examples
   build-depends:       base
                      , Glob
                      , QuickCheck
-                     , aeson
+                     , aeson >= 2.0.3
                      , aeson-diff
                      , bytestring
                      , directory
@@ -111,6 +111,7 @@ test-suite doctests
   build-depends:       base
                      , QuickCheck
                      , doctest >= 0.9
+                     , aeson >= 2.0.3
 
 test-suite             hlint-check
   buildable:           False

--- a/aeson-diff.cabal
+++ b/aeson-diff.cabal
@@ -14,7 +14,7 @@ author:              Thomas Sutton
 maintainer:          me@thomas-sutton.id.au
 copyright:           (c) 2015 Thomas Sutton and others.
 category:            JSON, Web, Algorithms
-build-type:          Simple
+build-type:          Custom
 cabal-version:       >=1.10
 extra-source-files:  README.md
                    , CHANGELOG.md
@@ -110,8 +110,9 @@ test-suite doctests
   main-is:             doctests.hs
   build-depends:       base
                      , QuickCheck
-                     , doctest >= 0.9
-                     , aeson >= 2.0.3
+                     , doctest >= 0.20
+  other-modules: Build_doctests
+
 
 test-suite             hlint-check
   buildable:           False
@@ -121,3 +122,8 @@ test-suite             hlint-check
   main-is:             hlint-check.hs
   build-depends:       base
                      , hlint
+
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   cabal-doctest >= 1 && <1.1

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -1,4 +1,5 @@
+import Build_doctests (flags, pkgs, module_sources)
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["-ilib", "lib"]
+main = doctest $ flags ++ pkgs ++ module_sources

--- a/test/properties.hs
+++ b/test/properties.hs
@@ -11,8 +11,7 @@ import           Control.Monad
 import           Data.Aeson                 as A
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Data.Functor
-import           Data.HashMap.Strict        (HashMap)
-import qualified Data.HashMap.Strict        as HM
+import qualified Data.Aeson.KeyMap          as HM
 import           Data.Monoid
 import           Data.Text                  (Text)
 import qualified Data.Vector                as V
@@ -56,18 +55,6 @@ instance Arbitrary (AnObject Value) where
 
 instance Arbitrary (AnArray Value) where
     arbitrary = AnArray . Array . V.fromList <$> scaleSize (`div` 2) arbitrary
-
-instance Arbitrary Value where
-    arbitrary = sized vals
-      where vals :: Int -> Gen Value
-            vals n
-              | n <= 1 = oneof
-                         [ pure Null
-                         , Bool <$> arbitrary
-                         , Number . fromIntegral <$> (arbitrary :: Gen Int)
-                         , String <$> arbitrary
-                         ]
-              | otherwise = wellformed <$> arbitrary
 
 
 -- | Extracting and applying a patch is an identity.


### PR DESCRIPTION
Fixes #60.

Tested using

    cabal test --constraint='aeson>=2' -w ghc-9.0.2

I opted to only support Aeson 2 since Aeson 1 users can just use existing releases. The code would have been ugly with many ifdefs if compatibility were to be retained.
